### PR TITLE
API9 fixes

### DIFF
--- a/CraftingList/CraftingList.cs
+++ b/CraftingList/CraftingList.cs
@@ -1,4 +1,4 @@
-﻿using CraftingList.Crafting;
+using CraftingList.Crafting;
 using CraftingList.Crafting.Macro;
 using CraftingList.SeFunctions;
 using CraftingList.UI.CraftingListTab;
@@ -46,7 +46,7 @@ namespace CraftingList
             Service.Initialize(pluginInterface, Configuration);
             //Service.init2(Configuration);
 
-            Service.GameInteropProvider.InitializeFromAttributes(this);
+            Service.GameInteropProvider.InitializeFromAttributes(Service.ChatManager);
 
             InitializeSingletons();
             SeInterface.Instance.InitializeHooks();

--- a/CraftingList/SeFunctions/PtrRepair.cs
+++ b/CraftingList/SeFunctions/PtrRepair.cs
@@ -1,16 +1,27 @@
-﻿using CraftingList.Utility;
+using CraftingList.Utility;
+using FFXIVClientStructs.Attributes;
 using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Component.GUI;
 using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+[Addon("Repair")]
+[StructLayout(LayoutKind.Explicit, Size = 0xF7E8)]
+unsafe struct AddonRepair65
+{
+    [FieldOffset(616)] public AtkComponentButton* RepairAllButton;
+}
 
 namespace CraftingList.SeFunctions
 {
     public unsafe struct PtrRepair
     {
         private const int repairAllButtonId = 25;
-        AddonRepair* AddonPointer;
+        AddonRepair65* AddonPointer;
 
         public static implicit operator PtrRepair(IntPtr pointer)
-            => new() { AddonPointer = Module.Cast<AddonRepair>(pointer) };
+            => new() { AddonPointer = Module.Cast<AddonRepair65>(pointer) };
 
         public static implicit operator bool(PtrRepair addonRepair)
         {

--- a/CraftingList/UI/CraftingListTab/EntryListTable.cs
+++ b/CraftingList/UI/CraftingListTab/EntryListTable.cs
@@ -1,4 +1,4 @@
-﻿using CraftingList.Crafting;
+using CraftingList.Crafting;
 using CraftingList.Crafting.Macro;
 using CraftingList.Utility;
 using Dalamud.Interface;
@@ -233,8 +233,8 @@ namespace CraftingList.UI.CraftingListTab
                         EstimateTime();
 
                         if (Service.Configuration.RecentRecipeIds.Count > 10)
-                            Service.Configuration.RecentRecipeIds.RemoveAt(Service.Configuration.RecentRecipeIds.Count);
-                        
+                            Service.Configuration.RecentRecipeIds.RemoveAt(Service.Configuration.RecentRecipeIds.Count - 1);
+
                         if (Service.Configuration.RecentRecipeIds.Contains(newEntry.RecipeId))
                             Service.Configuration.RecentRecipeIds.RemoveAll(x => x == newEntry.RecipeId);
 


### PR DESCRIPTION
Fixes 

Chat commands
https://github.com/drejjmit/CraftingList/commit/942cfc09219b7b74b9d1e9ea847b41fc4382f4b3
```
15:06:35.408 | DBG [CraftingList] [CraftHelper.ChangeJobs()] Changing jobs to Alchemist
15:06:35.417 | ERR Exception during raise of "Void b__0()"
System.NullReferenceException: Object reference not set to an instance of an object.
at CraftingList.Utility.ChatManager.SendMessageInternal(String message)
at CraftingList.Utility.ChatManager.FrameworkUpdate(IFramework framework)
at Dalamud.Utility.EventHandlerExtensions.HandleInvoke(Action act) in C:\goatsoft\companysecrets\dalamud\Utility\EventHandlerExtensions.cs:line 112
```

If a list has 10 entries, you can't call RemoveAt(10) because lists start at 0
https://github.com/drejjmit/CraftingList/commit/13d15dbc545651e3847d4f27f853eb38806a1407
```
11:32:01.495 ERR | Exception during raise of "Void DrawUI()"
11:32:01.495 ERR | System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
11:32:01.495 ERR |    at System.Collections.Generic.List`1.RemoveAt(Int32 index)
11:32:01.495 ERR |    at CraftingList.UI.CraftingListTab.EntryListTable.DrawNewEntry() in C:\Users\x\Source\Repos\CraftingList\CraftingList\UI\CraftingListTab\EntryListTable.cs:line 236
11:32:01.495 ERR |    at CraftingList.UI.CraftingListTab.CraftingListTab.Draw() in C:\Users\x\Source\Repos\CraftingList\CraftingList\UI\CraftingListTab\CraftingListTab.cs:line 36
11:32:01.495 ERR |    at CraftingList.PluginUI.DrawSettingsWindow() in C:\Users\x\Source\Repos\CraftingList\CraftingList\UI\PluginUI.cs:line 114
11:32:01.495 ERR |    at CraftingList.PluginUI.Draw() in C:\Users\x\Source\Repos\CraftingList\CraftingList\UI\PluginUI.cs:line 75
11:32:01.495 ERR |    at CraftingList.CraftingList.DrawUI() in C:\Users\x\Source\Repos\CraftingList\CraftingList\CraftingList.cs:line 147
11:32:01.495 ERR |    at Dalamud.Utility.EventHandlerExtensions.HandleInvoke(Action act) in C:\goatsoft\companysecrets\dalamud\Utility\EventHandlerExtensions.cs:line 112
```

Repair
https://github.com/drejjmit/CraftingList/commit/1284eb842109ade823b5673d6552db760f39bebf
```
11:33:35.990 ERR | Unobserved exception in Task.
11:33:35.990 ERR | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Object reference not set to an instance of an object.)
11:33:35.990 ERR |  ---> System.NullReferenceException: Object reference not set to an instance of an object.
11:33:35.990 ERR |    at CraftingList.SeFunctions.PtrRepair.ClickRepairAll() in C:\Users\x\Source\Repos\CraftingList\CraftingList\SeFunctions\PtrRepair.cs:line 24
11:33:35.990 ERR |    at CraftingList.Crafting.CraftHelper.Repair() in C:\Users\x\Source\Repos\CraftingList\CraftingList\Crafting\CraftHelper.cs:line 275
11:33:35.990 ERR |    at CraftingList.Crafting.Crafter.QuickSynthesizeEntry(CListEntry entry) in C:\Users\x\Source\Repos\CraftingList\CraftingList\Crafting\Crafter.cs:line 276
11:33:35.990 ERR |    at CraftingList.Crafting.Crafter.<CraftAllItems>b__5_0() in C:\Users\x\Source\Repos\CraftingList\CraftingList\Crafting\Crafter.cs:line 79
```

